### PR TITLE
git-status, ripgrep, show read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # shell
 
-My dynamic replacement for the default PS1. Bash.
+Alisa Sireneva's dynamic replacement for bash's PS1 written mainly in bash.
 
 ```
 . shell.sh                 # for nerdfont mode
 PS1_MODE=text . shell.sh   # for text mode
 ```
 
-Execute in bash shell or add to your `.bashrc`
+Execute in bash shell or add to your `.bashrc`.
 
-Two modes are available --- "nerdfont" and "text", former is default, latter is toggled by setting `PS1_MODE=text` before applying prompt
+Two modes are available --- "nerdfont" and "text", former is default, latter is toggled by setting `PS1_MODE=text` before applying prompt.
 
-TODO: add git: to pull, to push, stach count, add count, del count, untrack count
+# What does
+
+Pure bash (kind of) implementation of "git status into PS1" which does not break on empty repos; output format taken from [p10k](https://github.com/romkatv/powerlevel10k).
+
+Replace `/path/to/home/yuki` with `~yuki` if home directory of user `yuki` when using any other user.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Alisa Sireneva's dynamic replacement for bash's PS1 written mainly in bash.
 
+## Usage
+
 ```
 . shell.sh                 # for nerdfont mode
 PS1_MODE=text . shell.sh   # for text mode
@@ -11,7 +13,7 @@ Execute in bash shell or add to your `.bashrc`.
 
 Two modes are available --- "nerdfont" and "text", former is default, latter is toggled by setting `PS1_MODE=text` before applying prompt.
 
-# What does
+## What does
 
 Pure bash (kind of) implementation of "git status into PS1" which does not break on empty repos; output format taken from [p10k](https://github.com/romkatv/powerlevel10k).
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Execute in bash shell or add to your `.bashrc`.
 
 Two modes are available --- "nerdfont" and "text", former is default, latter is toggled by setting `PS1_MODE=text` before applying prompt.
 
+Can use ripgrep if available (default), or if passed `PS1_RG=none` (anything other than `ok` does the job too) uses grep+sed.
+
 ## What does
 
 Pure bash (kind of) implementation of "git status into PS1" which does not break on empty repos; output format taken from [p10k](https://github.com/romkatv/powerlevel10k).

--- a/shell.sh
+++ b/shell.sh
@@ -146,6 +146,12 @@ async_prompt() {
 	if [ -f jr ]; then
 		local buildinfo="${buildinfo}./jr "
 	fi
+	if compgen -G "*.qbs" > /dev/null; then
+		local buildinfo="${buildinfo}qbs "
+	fi
+	if compgen -G "*.pro" > /dev/null; then
+		local buildinfo="${buildinfo}qmake "
+	fi
 	if [ -n "$buildinfo" ]; then
 		local buildinfo="$(printf $BOLD$PURPLE)[${buildinfo%?}]$(printf $RESET) "
 	fi

--- a/shell.sh
+++ b/shell.sh
@@ -227,8 +227,11 @@ async_prompt() {
 				local name="$(rg "name=['\"](.+)['\"]" $setup_py -or '$1' -m 1)"
 				local version="$(rg "version=['\"](.+)['\"]" $setup_py -or '$1' -m 1)"
 			else
-				local name="<ripgrep>"
-				local version=""
+				# TODO rewrite!!
+				# local name="<ripgrep>"
+				# local version=""
+				local name="$(grep "^\s*name\s*=\s*\"[^\"]*\"" "$setup_py" | sed -E "s/^\s*name\s*=\s*\"([^\"]*)\".*/\1/" | head -1)"
+				local version="$(grep "^\s*version\s*=\s*\"[^\"]*\"" "$setup_py" | sed -E "s/^\s*version\s*=\s*\"([^\"]*)\".*/\1/" | head -1)"
 			fi
 			if [ -n "$version" ]; then
 				local version=" $version"
@@ -288,12 +291,11 @@ async_prompt() {
 			rg "^$HOME" -r "$BOLD$YELLOW~$RESET" --passthru
 		)"
 	else
-		local curdir="<rg>"
-		#local curdir="$(
-		#	( [[ "$PWD" == "$gitroot" ]] && echo "$PWD/" || echo "$PWD" ) |
-		#	( [ -n "$gitroot" ] && sed -E "s|^($gitroot)(.*)|\1$CYAN\2$RESET|" || cat ) |
-		#	sed -E "s|^$HOME|$BOLD$YELLOW~$RESET|"
-		#)"
+		local curdir="$(
+			( [[ "$PWD" == "$gitroot" ]] && echo "$PWD/" || echo "$PWD" ) |
+			( [ -n "$gitroot" ] && sed -E "s|^($gitroot)(.*)|\1$CYAN\2$RESET|" || cat ) |
+			sed -E "s|^$HOME|$BOLD$YELLOW~$RESET|"
+		)"
 	fi
 	local curdir="$(replace_home $curdir)"
 

--- a/shell.sh
+++ b/shell.sh
@@ -34,6 +34,7 @@ if [ "$PS1_MODE" == "text" ]; then
 	RETURN_FAIL="Failed"
 	HOST_TEXT="at "
 	USER_TEXT="as "
+	READONLY="R/O"
 else
 	BRANCH=""
 	NODE_PACKAGE=""
@@ -45,6 +46,7 @@ else
 	RETURN_FAIL="✗"
 	HOST_TEXT=""
 	USER_TEXT=""
+	READONLY=""
 fi
 
 INVALID_HOMES='^(/$|(/bin|/dev|/proc|/usr|/var)[/$])'
@@ -187,6 +189,10 @@ async_prompt() {
 		rg "^$HOME" -r "$BOLD$YELLOW~$RESET" --passthru
 	)"
 	local curdir="$(replace_home $curdir)"
+
+	if [ ! -w $PWD ]; then
+		local curdir="$RED$READONLY$RESET $curdir"
+	fi
 
 	if [[ $command_duration -gt 1000 ]]; then
 		local runtime=" $CYAN($EXEC_DURATION $(($command_duration / 1000))s)$RESET"


### PR DESCRIPTION
Added `PS1_RG` switch and `ripgrep` detector to use `rg` instead of `grep`+`sed`, because code with `rg` is somewhat cleaner.

Added `qbs` and `qmake` projects detector.

Added "is working directory read-only".

Added powerlevel10k-inspired git status display.

Fixed README to mirror changes.

---

New git-status code fixes "empty branch" on newly created repos (screenshot included).

![image](https://github.com/imachug/shell/assets/44705138/f7dedfa7-e84b-461a-9c2b-9a92087d09eb)
