### PR TITLE
hostnamectl-taken host icon

### DIFF
--- a/shell.sh
+++ b/shell.sh
@@ -49,7 +49,8 @@ else
     EXEC_DURATION=""
     RETURN_OK="✓"
     RETURN_FAIL="✗"
-    HOST_TEXT="󰒋"
+    #HOST_TEXT="󰒋"
+    HOST_TEXT="$(hostnamectl | rg '\s+Chassis: [a-z]+ (.+)' --replace '$1')"
     USER_TEXT=""
     READONLY=""
 fi

--- a/shell.sh
+++ b/shell.sh
@@ -374,7 +374,7 @@ get_shell_ps1() {
     local cur_date="$(LC_TIME=en_US.UTF-8 date +'%a, %Y-%b-%d, %H:%M:%S in %Z')"
     printf "\n$HOSTUSER$ESC[$(($COLUMNS - ${#cur_date}))G$GREY$cur_date$RESET\n$jobinfo$retinfo$cursor "
 
-    async_prompt $PS1_RG >/dev/null &
+    async_prompt >/dev/null &
     echo "$!" >"/tmp/asyncpromptpid$$"
 }
 


### PR DESCRIPTION
I've noticed that `hostnamectl` outputs icons for different machine types and have taken them to this status line.

![image](https://github.com/purplesyringa/shell/assets/44705138/c1a96bb1-62f2-444a-ad67-0110df0c64a1)


I have also fixed the leftovers of "grep" mode because we only support ripgrep now